### PR TITLE
Improve gemspec and update dependencies

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,0 +1,8 @@
+lib/litl.rb
+lib/litl/engine.rb
+lib/litl/litl.treetop
+lib/litl/litl_grammar.treetop
+lib/litl/parser.rb
+lib/litl/template.rb
+lib/litl/version.rb
+README.md

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rake/clean"
 require "bundler/gem_tasks"
-
+require "rake/clean"
+require "rake/manifest/task"
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
@@ -11,4 +11,9 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task default: [:test]
+Rake::Manifest::Task.new do |t|
+  t.patterns = ["{lib}/**/*", "*.md"]
+end
+
+task build: ["manifest:check"]
+task default: [:test, "manifest:check"]

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "treetop", "~> 1.6"
 
   spec.add_development_dependency "minitest", "~> 5.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rubocop", "~> 1.23.0"
   spec.add_development_dependency "rubocop-minitest", "~> 0.17.0"

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "tilt", "~> 2.0"
   spec.add_runtime_dependency "treetop", "~> 1.6"
 
-  spec.add_development_dependency "indentation"
   spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -12,14 +12,11 @@ Gem::Specification.new do |spec|
   spec.description = "Lisp-inspired Template Language"
   spec.homepage = ""
   spec.license = "MIT"
-
   spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = `git ls-files -z`.split("\0")
-
-  spec.test_files = spec.files.grep(%r{^test/})
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency("temple", "~> 0.8.0")

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.files = `git ls-files -z`.split("\0")
+  spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "temple", "~> 0.8.0"
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "indentation"
   spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rubocop", "~> 1.23.0"
   spec.add_development_dependency "rubocop-minitest", "~> 0.17.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.12.0"

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -19,16 +19,15 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\0")
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("temple", "~> 0.8.0")
-  spec.add_runtime_dependency("tilt", "~> 2.0")
-  spec.add_runtime_dependency("treetop", "~> 1.6")
+  spec.add_runtime_dependency "temple", "~> 0.8.0"
+  spec.add_runtime_dependency "tilt", "~> 2.0"
+  spec.add_runtime_dependency "treetop", "~> 1.6"
 
-  spec.add_development_dependency("indentation")
-  spec.add_development_dependency("minitest", ["~> 5.6"])
-  spec.add_development_dependency("rake")
-
-  spec.add_development_dependency("rubocop", "~> 1.23.0")
-  spec.add_development_dependency("rubocop-minitest", "~> 0.17.0")
-  spec.add_development_dependency("rubocop-performance", "~> 1.12.0")
-  spec.add_development_dependency("rubocop-rake", "~> 0.6.0")
+  spec.add_development_dependency "indentation"
+  spec.add_development_dependency "minitest", "~> 5.6"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rubocop", "~> 1.23.0"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.17.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.12.0"
+  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,4 @@
 
 require "minitest/autorun"
 
-require "indentation"
-
 require "litl"


### PR DESCRIPTION
- Remove test_files gemspec attribute
- Clean up formatting of dependency definitions
- Use rake-manifest to maintain the list of files to ship
- Remove obsolete 'indentation' dependency
- Tighten rake dependency
