### PR TITLE
Update RuboCop setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Layout/FirstArrayElementLineBreak:
 Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_mode:
 
 require:
   - rubocop-minitest
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rake
 

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-minitest", "~> 0.20.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
 end

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-minitest", "~> 0.20.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
- Add rubocop-packaging plugin
