### PR TITLE
Bump RuboCop to 1.34 to avoid configuration errors

### DIFF
--- a/litl.gemspec
+++ b/litl.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.32"
+  spec.add_development_dependency "rubocop", "~> 1.34"
   spec.add_development_dependency "rubocop-minitest", "~> 0.21.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"


### PR DESCRIPTION
Version 1.33 of RuboCop broke `RuboCop::ConfigLoader.project_root`, leading to errors in rubocop-packaging. Require at least 1.34 to avoid this.
