### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Add line break so element indentation will match with standardrb
 Layout/FirstArrayElementLineBreak:
   Enabled: true

--- a/litl.gemspec
+++ b/litl.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.6"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.34"
+  spec.add_development_dependency "rubocop", "~> 1.51"
   spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.1"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13"
+  spec.add_development_dependency "rubocop-performance", "~> 1.18"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
 end


### PR DESCRIPTION
- Bump versions for rubocop and friends
- Require development dependencies to be in the gemspec
